### PR TITLE
Add header and url to package_data to fix pip installs from VCS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(
         description='Python client for Imbo',
         long_description=open('README.md').read(),
         install_requires=['requests', 'nose', 'mock', 'coverage'],
+        package_data={'imboclient': ['header/*', 'url/*'], },
 )
 


### PR DESCRIPTION
pip installations directly from VCS does not include the `header`
and `url` modules by default, so they have to be included in the
`package_data` dependency in setup.py.
