### PR TITLE
Include .md file, set first pypi release version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.txt
+include *.md
 recursive-include docs *.txt
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
         name='imboclient',
-        version='0.0.1',
+        version='0.0.1b',
         author='Andreas Søvik',
         author_email='arsovik@gmail.com',
         packages=['imboclient'],


### PR DESCRIPTION
This brings the github version in sync with the current released version on pypi, ensuring that imboclient is installable through `pip`.