### PR TITLE
Alias image_exists to image_identifier_exists

### DIFF
--- a/imboclient/client.py
+++ b/imboclient/client.py
@@ -64,9 +64,8 @@ class Client:
 
         return self.add_image_from_string(image_string)
 
-    def image_exists(self, path):
-        image_identifier = self.image_identifier(path)
-        return self.image_identifier_exists(image_identifier)
+    def image_exists(self, imbo_id):
+        return self.image_identifier_exists(imbo_id)
 
     def image_identifier_exists(self, image_identifier):
         result = self.head_image(image_identifier)


### PR DESCRIPTION
Since we no longer use the client side md5() as the image identifier in Imbo by default, image_exists is more suitable as an alias for image_identifier_exists. If you need the old functionality, add hash the existing file before calling the method.

Keeping this method without changing it would create confusion further along the way, and since we don't really have any major BC issues (as the library isn't used _that_ much at the moment), I'm breaking it now before we move on to the next release.