### PR TITLE
Update tests to work with the most recent version of Imbo

### DIFF
--- a/imboclient/client.py
+++ b/imboclient/client.py
@@ -94,7 +94,6 @@ class Client:
 
         headers['Accept'] = 'application/json'
         headers['Content-Type'] = 'application/json'
-        headers['Content-Length'] = len(metadata)
         headers['Content-MD5'] = hashlib.md5(metadata).hexdigest()
 
         def http_edit_metadata(self):
@@ -109,7 +108,6 @@ class Client:
 
         headers['Accept'] = 'application/json'
         headers['Content-Type'] = 'application/json'
-        headers['Content-Length'] = len(metadata)
         headers['Content-MD5'] = hashlib.md5(metadata).hexdigest()
 
         def http_replace_metadata(self):

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -236,7 +236,7 @@ class TestClient:
 
         mock_requests_post.assert_called_once_with('metadataurl',
                                                    data=metadata,
-                                                   headers={'Accept': 'application/json', 'Content-Type': 'application/json', 'Content-Length': len(metadata), 'Content-MD5': hashlib.md5(metadata).hexdigest()}
+                                                   headers={'Accept': 'application/json', 'Content-Type': 'application/json', 'Content-MD5': hashlib.md5(metadata).hexdigest()}
                                                    )
 
     @patch('imboclient.header.authenticate.Authenticate.headers')
@@ -261,7 +261,7 @@ class TestClient:
 
         mock_requests_put.assert_called_once_with('metadataurl',
                                                   data=metadata,
-                                                  headers={'Accept': 'application/json', 'Content-Type': 'application/json', 'Content-Length': len(metadata), 'Content-MD5': hashlib.md5(metadata).hexdigest()}
+                                                  headers={'Accept': 'application/json', 'Content-Type': 'application/json', 'Content-MD5': hashlib.md5(metadata).hexdigest()}
                                                   )
 
     @patch('imboclient.header.authenticate.Authenticate.headers')

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -151,17 +151,14 @@ class TestClient:
         mock_requests_get.assert_called_once_with('validimageurl')
         mock_add_image_from_string.assert_called_once_with('imagedatafromhttp')
 
-    @patch('imboclient.client.Client.image_identifier')
     @patch('imboclient.client.Client.image_identifier_exists')
-    def test_image_exists(self, mock_image_identifier_exists, mock_image_identifier):
-        mock_image_identifier.return_value = 'identifier'
+    def test_image_exists(self, mock_image_identifier_exists):
         mock_image_identifier_exists.return_value = True
 
-        image_exists = self._client.image_exists('/dummy/path')
+        image_exists = self._client.image_exists('identifier')
 
         assert image_exists is True
         mock_image_identifier_exists.assert_called_once_with('identifier')
-        mock_image_identifier.assert_called_once_with('/dummy/path')
 
     @patch('requests.head')
     @patch('imboclient.url.image.UrlImage')


### PR DESCRIPTION
OK, time to get this show back on the road.

Most tests depend on the old behaviour of Imbo to use the md5()-hash of the image as
the identifier. This is no longer true, so I've rewritten the tests to always use
the image identifier returned from the server instead of assuming that it's the same
 as the hash of the file on disk.