### PR TITLE
Merge py2 and py3 branch to a single branch.

### DIFF
--- a/imboclient/client.py
+++ b/imboclient/client.py
@@ -1,6 +1,5 @@
 import requests
 import re
-from urllib.parse import urlparse
 import os.path
 import time
 import hashlib
@@ -13,6 +12,12 @@ from imboclient.url import user
 from imboclient.url import status
 from imboclient.url import metadata
 
+try:
+    # py3
+    from urllib.parse import urlparse
+except ImportError:
+    # py2
+    from urlparse import urlparse
 
 class Client:
     def __init__(self, server_urls, public_key, private_key, version=None):

--- a/imboclient/header/authenticate.py
+++ b/imboclient/header/authenticate.py
@@ -1,6 +1,6 @@
 import hmac
 import hashlib
-
+import sys
 
 class Authenticate:
     def __init__(self, public_key, private_key, method, url, timestamp):
@@ -11,9 +11,15 @@ class Authenticate:
         self.url = url
         self.timestamp = timestamp
 
-    def _generate_auth_hash(self):
-        data = bytes(self.method + '|' + self.url + '|' + self._public_key + '|' + self.timestamp, 'utf-8')
-        return hmac.new(bytes(self._private_key, 'utf-8'), data, hashlib.sha256).hexdigest()
+    def _generate_auth_hash(self):        
+        data = self.method + '|' + self.url + '|' + self._public_key + '|' + self.timestamp
+        private_key = self._private_key
+
+        if sys.version_info >= (3,):
+            data = bytes(data, 'utf-8')
+            private_key = bytes(self._private_key, 'utf-8')
+
+        return hmac.new(private_key, data, hashlib.sha256).hexdigest()
 
     def headers(self):
         signature = self._generate_auth_hash()

--- a/imboclient/test/integration/test_client.py
+++ b/imboclient/test/integration/test_client.py
@@ -87,16 +87,16 @@ class TestClient:
 
     def test_num_images(self):
         result = self._client.num_images()
-        assert result == 0
+        assert result >= 0
 
     def test_images(self):
         result = self._client.images()
 
-        assert len(result['images']) == 0
+        assert 'images' in result
         assert result['search']
-        assert result['search']['count'] == 0
-        assert result['search']['hits'] == 0
-        assert result['search']['limit'] != 0
+        assert 'count' in result['search']
+        assert 'hits' in result['search']
+        assert result['search']['limit'] > 0
         assert result['search']['page'] == 1
 
     def test_image_data(self):

--- a/imboclient/url/accesstoken.py
+++ b/imboclient/url/accesstoken.py
@@ -1,8 +1,12 @@
 import hmac
 import hashlib
+import sys
 
 
 class AccessToken:
     def generate_token(self, url, key):
-        return hmac.new(bytes(key, 'utf-8'), bytes(url, 'utf-8'), hashlib.sha256).hexdigest()
+        if sys.version_info < (3,):
+            return hmac.new(key, url, hashlib.sha256).hexdigest()
+        else:
+            return hmac.new(bytes(key, 'utf-8'), bytes(url, 'utf-8'), hashlib.sha256).hexdigest()
 

--- a/imboclient/url/url.py
+++ b/imboclient/url/url.py
@@ -1,5 +1,9 @@
 from imboclient.url import accesstoken
-import urllib.parse
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
 import json
 
 
@@ -52,7 +56,7 @@ class Url(object):
     def query_string(self):
         if not self._query_params:
             return ''
-        return urllib.parse.urlencode(self._query_params)
+        return urlencode(self._query_params)
 
     def resource_url(self):
         raise NotImplementedError("Missing implementation. You may want to use a Url implementation instead.")


### PR DESCRIPTION
This integrates the py2 and py3 branches to a single branch with explicit version checking where necessary (in particular in the places where we need to know if we're working with bytes or actual strings).

Future fixes should hopefully not have to touch this. If we find that future maintenance require extending our current version testing, we might want to wrap certain string handling in `six` or a similar library. Most changes are in the hmac functions in how we bytes are obtained between py2 and py3.

I do however think that we'll go with just py3.5 at some time in the future, finally deprecating the 2.7 version.

I've also changed one of the test cases to not assume that the imbo server is empty, as this is just a side effect of how the tests run. Since I'm lazy, I'm not creating a separate PR for this small fix this time. Other test cases didn't need the builtin open function mocked, so I've removed those mocks. Where the mocks are necessary, I've replaced them with the now available mock_open helper from the mock library, and added code to use them in a proper with: statement to be able to dynamically pick which builtin module we should refer to.

I'm going to merge this on Sunday or Monday barring any comments.