### PR TITLE
Support imbo users

### DIFF
--- a/imboclient/client.py
+++ b/imboclient/client.py
@@ -20,14 +20,15 @@ except ImportError:
     from urlparse import urlparse
 
 class Client:
-    def __init__(self, server_urls, public_key, private_key, version=None):
+    def __init__(self, server_urls, public_key, private_key, version=None, user=None):
         self.server_urls = self._parse_urls(server_urls)
         self._public_key = public_key
         self._private_key = private_key
         self._version = version
+        self._user = user
 
     def metadata_url(self, image_identifier):
-        return metadata.UrlMetadata(self.server_urls[0], self._public_key, self._private_key, image_identifier)
+        return metadata.UrlMetadata(self.server_urls[0], self._public_key, self._private_key, image_identifier, user=self._user)
 
     def status_url(self):
         return status.UrlStatus(self.server_urls[0], self._public_key, self._private_key)
@@ -36,10 +37,10 @@ class Client:
         return user.UrlUser(self.server_urls[0], self._public_key, self._private_key)
 
     def images_url(self):
-        return images.UrlImages(self.server_urls[0], self._public_key, self._private_key)
+        return images.UrlImages(self.server_urls[0], self._public_key, self._private_key, user=self._user)
 
     def image_url(self, image_identifier):
-        return image.UrlImage(self.server_urls[0], self._public_key, self._private_key, image_identifier)
+        return image.UrlImage(self.server_urls[0], self._public_key, self._private_key, image_identifier, user=self._user)
 
     def add_image(self, path):
         image_file_data = self._image_file_data(path)

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -16,39 +16,39 @@ import sys
 
 class TestClient:
     def setup(self):
-        self._client = imbo.Client(['http://imbo.local'], 'public', 'private');
-        self._client_with_user = imbo.Client(['http://imbo.local'], 'public', 'private', user='foo');
+        self._client = imbo.Client(['http://imbo.local'], 'public', 'private')
+        self._client_with_user = imbo.Client(['http://imbo.local'], 'public', 'private', user='foo')
 
     def teardown(self):
         self._client = None
         self._client_with_user = None
 
     def test_server_urls_generic(self):
-        self._client = imbo.Client(['imbo.local'], 'public', 'private');
+        self._client = imbo.Client(['imbo.local'], 'public', 'private')
         assert self._client.server_urls[0] == 'http://imbo.local'
 
     def test_server_urls_http(self):
-        self._client = imbo.Client(['http://imbo.local'], 'public', 'private');
+        self._client = imbo.Client(['http://imbo.local'], 'public', 'private')
         assert self._client.server_urls[0] == 'http://imbo.local'
 
     def test_server_urls_https(self):
-        self._client = imbo.Client(['https://imbo.local'], 'public', 'private');
+        self._client = imbo.Client(['https://imbo.local'], 'public', 'private')
         assert self._client.server_urls[0] == 'https://imbo.local'
 
     def test_server_urls_port_normal(self):
-        self._client = imbo.Client(['http://imbo.local'], 'public', 'private');
+        self._client = imbo.Client(['http://imbo.local'], 'public', 'private')
         assert self._client.server_urls[0] == 'http://imbo.local'
 
     def test_server_urls_port_normal_explicit(self):
-        self._client = imbo.Client(['http://imbo.local:80'], 'public', 'private');
+        self._client = imbo.Client(['http://imbo.local:80'], 'public', 'private')
         assert self._client.server_urls[0] == 'http://imbo.local'
 
     def test_server_urls_port_ssl(self):
-        self._client = imbo.Client(['https://imbo.local:443'], 'public', 'private');
+        self._client = imbo.Client(['https://imbo.local:443'], 'public', 'private')
         assert self._client.server_urls[0] == 'https://imbo.local'
 
     def test_server_urls_port_explicit_without_protocol(self):
-        self._client = imbo.Client(['imbo.local:8000'], 'public', 'private');
+        self._client = imbo.Client(['imbo.local:8000'], 'public', 'private')
         assert self._client.server_urls[0] == 'http://imbo.local:8000'
 
     @patch('imboclient.url.status.UrlStatus')

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -75,6 +75,10 @@ class TestClient:
         mocked_url_images.assert_called_once_with('http://imbo.local', 'public', 'private', user='foo')
         assert images_url == mocked_url_images()
 
+    def test_images_url_with_user_used(self):
+        images_url = self._client_with_user.images_url()
+        assert images_url.url().startswith('http://imbo.local/users/foo/images')
+
     @patch('imboclient.url.image.UrlImage')
     def test_image_url(self, mocked_url_image):
         image_url = self._client.image_url('ff')
@@ -87,6 +91,10 @@ class TestClient:
         mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff', user='foo')
         assert image_url == mocked_url_image()
 
+    def test_image_url_with_user_used(self):
+        image_url = self._client_with_user.image_url('ff')
+        assert image_url.url().startswith('http://imbo.local/users/foo/images/ff?')
+
     @patch('imboclient.url.metadata.UrlMetadata')
     def test_metadata_url(self, mocked_url_metadata):
         metadata_url = self._client.metadata_url('ff')
@@ -98,6 +106,10 @@ class TestClient:
         metadata_url = self._client_with_user.metadata_url('ff')
         mocked_url_metadata.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff', user='foo')
         assert metadata_url == mocked_url_metadata()
+
+    def test_metadata_url_with_user_used(self):
+        metadata_url = self._client_with_user.metadata_url('ff')
+        assert metadata_url.url().startswith('http://imbo.local/users/foo/images/ff/metadata?')
 
     @patch('imboclient.header.authenticate.Authenticate.headers')
     @patch('imboclient.url.images.UrlImages.url')

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -64,19 +64,19 @@ class TestClient:
     @patch('imboclient.url.images.UrlImages')
     def test_images_url(self, mocked_url_images):
         images_url = self._client.images_url()
-        mocked_url_images.assert_called_once_with('http://imbo.local', 'public', 'private')
+        mocked_url_images.assert_called_once_with('http://imbo.local', 'public', 'private', user=None)
         assert images_url == mocked_url_images()
 
     @patch('imboclient.url.image.UrlImage')
     def test_image_url(self, mocked_url_image):
         image_url = self._client.image_url('ff')
-        mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff')
+        mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff', user=None)
         assert image_url == mocked_url_image()
 
     @patch('imboclient.url.metadata.UrlMetadata')
     def test_metadata_url(self, mocked_url_metadata):
         metadata_url = self._client.metadata_url('ff')
-        mocked_url_metadata.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff')
+        mocked_url_metadata.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff', user=None)
         assert metadata_url == mocked_url_metadata()
 
     @patch('imboclient.header.authenticate.Authenticate.headers')
@@ -178,7 +178,6 @@ class TestClient:
 
         assert self._client.image_identifier_exists('ff') is True
         mocked_requests_head.assert_called_once_with('http://imbo.local/users/public/ff?accessToken=aa')
-        mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff')
 
     @patch('requests.head')
     @patch('imboclient.url.image.UrlImage')
@@ -189,7 +188,7 @@ class TestClient:
 
         assert self._client.image_identifier_exists('ffa') is False
         mocked_requests_get.assert_called_once_with('http://imbo.local/users/public/ffa?accessToken=aaf')
-        mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ffa')
+        mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ffa', user=None)
 
     @patch('imboclient.url.image.UrlImage.url')
     @patch('requests.head')

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -17,9 +17,11 @@ import sys
 class TestClient:
     def setup(self):
         self._client = imbo.Client(['http://imbo.local'], 'public', 'private');
+        self._client_with_user = imbo.Client(['http://imbo.local'], 'public', 'private', user='foo');
 
     def teardown(self):
         self._client = None
+        self._client_with_user = None
 
     def test_server_urls_generic(self):
         self._client = imbo.Client(['imbo.local'], 'public', 'private');
@@ -67,16 +69,34 @@ class TestClient:
         mocked_url_images.assert_called_once_with('http://imbo.local', 'public', 'private', user=None)
         assert images_url == mocked_url_images()
 
+    @patch('imboclient.url.images.UrlImages')
+    def test_images_url_with_user(self, mocked_url_images):
+        images_url = self._client_with_user.images_url()
+        mocked_url_images.assert_called_once_with('http://imbo.local', 'public', 'private', user='foo')
+        assert images_url == mocked_url_images()
+
     @patch('imboclient.url.image.UrlImage')
     def test_image_url(self, mocked_url_image):
         image_url = self._client.image_url('ff')
         mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff', user=None)
         assert image_url == mocked_url_image()
 
+    @patch('imboclient.url.image.UrlImage')
+    def test_image_url_with_user(self, mocked_url_image):
+        image_url = self._client_with_user.image_url('ff')
+        mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff', user='foo')
+        assert image_url == mocked_url_image()
+
     @patch('imboclient.url.metadata.UrlMetadata')
     def test_metadata_url(self, mocked_url_metadata):
         metadata_url = self._client.metadata_url('ff')
         mocked_url_metadata.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff', user=None)
+        assert metadata_url == mocked_url_metadata()
+
+    @patch('imboclient.url.metadata.UrlMetadata')
+    def test_metadata_url_with_user(self, mocked_url_metadata):
+        metadata_url = self._client_with_user.metadata_url('ff')
+        mocked_url_metadata.assert_called_once_with('http://imbo.local', 'public', 'private', 'ff', user='foo')
         assert metadata_url == mocked_url_metadata()
 
     @patch('imboclient.header.authenticate.Authenticate.headers')
@@ -188,7 +208,6 @@ class TestClient:
 
         assert self._client.image_identifier_exists('ffa') is False
         mocked_requests_get.assert_called_once_with('http://imbo.local/users/public/ffa?accessToken=aaf')
-        mocked_url_image.assert_called_once_with('http://imbo.local', 'public', 'private', 'ffa', user=None)
 
     @patch('imboclient.url.image.UrlImage.url')
     @patch('requests.head')

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -78,6 +78,7 @@ class TestClient:
     def test_images_url_with_user_used(self):
         images_url = self._client_with_user.images_url()
         assert images_url.url().startswith('http://imbo.local/users/foo/images')
+        assert 'publicKey=public' in images_url.url()
 
     @patch('imboclient.url.image.UrlImage')
     def test_image_url(self, mocked_url_image):
@@ -94,6 +95,7 @@ class TestClient:
     def test_image_url_with_user_used(self):
         image_url = self._client_with_user.image_url('ff')
         assert image_url.url().startswith('http://imbo.local/users/foo/images/ff?')
+        assert 'publicKey=public' in image_url.url()
 
     @patch('imboclient.url.metadata.UrlMetadata')
     def test_metadata_url(self, mocked_url_metadata):
@@ -110,6 +112,7 @@ class TestClient:
     def test_metadata_url_with_user_used(self):
         metadata_url = self._client_with_user.metadata_url('ff')
         assert metadata_url.url().startswith('http://imbo.local/users/foo/images/ff/metadata?')
+        assert 'publicKey=public' in metadata_url.url()
 
     @patch('imboclient.header.authenticate.Authenticate.headers')
     @patch('imboclient.url.images.UrlImages.url')

--- a/imboclient/url/image.py
+++ b/imboclient/url/image.py
@@ -3,12 +3,12 @@ from imboclient.url import url
 
 
 class UrlImage (url.Url):
-    def __init__(self, base_url, public_key, private_key, image_identifier):
-        url.Url.__init__(self, base_url, public_key, private_key)
+    def __init__(self, base_url, public_key, private_key, image_identifier, user=None):
+        url.Url.__init__(self, base_url, public_key, private_key, user=user)
         self._image_identifier = image_identifier
 
     def resource_url(self):
-        return self._base_url + '/users/' + self._public_key + '/images/' + self._image_identifier
+        return self.user_url('images/' + self._image_identifier)
 
     def border(self, color='000000', width=1, height=1):
         self.add_query_param('t[]', "border:color={},width={},height={}".format(color, width, height))

--- a/imboclient/url/images.py
+++ b/imboclient/url/images.py
@@ -3,8 +3,8 @@ from imboclient.url import url
 
 
 class UrlImages (url.Url):
-    def __init__(self, base_url, public_key, private_key):
-        super(UrlImages, self).__init__(base_url, public_key, private_key)
+    def __init__(self, base_url, public_key, private_key, user=None):
+        super(UrlImages, self).__init__(base_url, public_key, private_key, user=user)
 
     def resource_url(self):
-        return self._base_url + '/users/' + self._public_key + '/images.json'
+        return self.user_url('images.json')

--- a/imboclient/url/metadata.py
+++ b/imboclient/url/metadata.py
@@ -3,9 +3,9 @@ from imboclient.url import url
 
 
 class UrlMetadata (url.Url):
-    def __init__(self, base_url, public_key, private_key, image_identifier):
-        url.Url.__init__(self, base_url, public_key, private_key)
+    def __init__(self, base_url, public_key, private_key, image_identifier, user=None):
+        url.Url.__init__(self, base_url, public_key, private_key, user=user)
         self._image_identifier = image_identifier
 
     def resource_url(self):
-        return self._base_url + '/users/' + self._public_key + '/images/' + self._image_identifier + '/' + 'metadata'
+        return self.user_url('images/' + self._image_identifier + '/' + 'metadata')

--- a/imboclient/url/url.py
+++ b/imboclient/url/url.py
@@ -8,14 +8,21 @@ import json
 
 
 class Url(object):
-    def __init__(self, base_url, public_key, private_key):
+    def __init__(self, base_url, public_key, private_key, user=None):
         self._base_url = base_url
         self._public_key = public_key
         self._private_key = private_key
+        self._user = user
         self._query_params = None
+
+        self.access_token = accesstoken.AccessToken()
 
     def __str__(self):
         return self.url()
+
+    def user_url(self, resource):
+        u = self._user if self._user else self._public_key
+        return self._base_url + '/users/' + u + '/' + resource
 
     def url(self):
         url = self.resource_url()
@@ -27,7 +34,6 @@ class Url(object):
         if self._public_key is None or self._private_key is None:
             return url
 
-        self.access_token = accesstoken.AccessToken()
         generated_token = self.access_token.generate_token(url, self._private_key)
 
         if self._query_params is None:

--- a/imboclient/url/url.py
+++ b/imboclient/url/url.py
@@ -22,6 +22,7 @@ class Url(object):
 
     def user_url(self, resource):
         u = self._user if self._user else self._public_key
+
         return self._base_url + '/users/' + u + '/' + resource
 
     def url(self):
@@ -46,6 +47,7 @@ class Url(object):
             self._query_params = []
 
         self._query_params.append((key, value))
+
         return self
 
     def add_query(self, query):
@@ -54,6 +56,7 @@ class Url(object):
             self.add_query_param('limit', query.limit())
             self.add_query_param('from', query.q_from())
             self.add_query_param('to', query.q_to())
+
         if query.metadata:
             self.add_query_param('query', json.dumps(query.query()))
 
@@ -62,6 +65,7 @@ class Url(object):
     def query_string(self):
         if not self._query_params:
             return ''
+
         return urlencode(self._query_params)
 
     def resource_url(self):
@@ -69,4 +73,5 @@ class Url(object):
 
     def reset(self):
         self._query_params = []
+
         return self


### PR DESCRIPTION
Modern versions of Imbo has separated 'public_key' and 'user' into separate concepts. This patch makes the client accept a 'user' parameter in its constructor which will override usage of `public_key` after `/user` in the URL generated.