### PR TITLE
Expose Client and Query classes directly

### DIFF
--- a/imboclient/__init__.py
+++ b/imboclient/__init__.py
@@ -1,0 +1,1 @@
+from .client import Client

--- a/imboclient/__init__.py
+++ b/imboclient/__init__.py
@@ -1,1 +1,2 @@
 from .client import Client
+from .url.imagesquery import Query

--- a/imboclient/__init__.py
+++ b/imboclient/__init__.py
@@ -1,2 +1,2 @@
 from .client import Client
-from .url.imagesquery import Query
+from .url.imagesquery import Query as ImagesQuery


### PR DESCRIPTION
These two classes are the main public interface that users are expected to use in the client, so they should be exposed directly under the module. 

This allows us to get rid of the deep syntax of `imboclient.client.Client`, replacing it with `from imboclient import Client` or just `imboclient.Client`. The same will be true for the `Query` class, allowing users to use the class directly from the module (`from imboclient import Query`) instead of searching through imboclient.url.imagesquery to find Query.

I'm considering if we should expose Query as `ImagesQuery` to avoid future clashes with UserQuery or similar. Any opinions?