### PR TITLE
Clean up url handling

### DIFF
--- a/imboclient/client.py
+++ b/imboclient/client.py
@@ -251,10 +251,6 @@ class Client:
     def _generate_image_identifier(self, content):
         return hashlib.md5(content).hexdigest()
 
-    def _host_for_image_identifier(self, image_identifier):
-        dec = int(image_identifier[0] + image_identifier[1], 16)
-        return self.server_urls[dec % len(self.server_urls)]
-
     def _wrap_result_json(self, function, success_status_codes, error):
         try:
             response = self._wrap_result(function, success_status_codes, error)

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -51,6 +51,10 @@ class TestClient:
         self._client = imbo.Client(['imbo.local:8000'], 'public', 'private')
         assert self._client.server_urls[0] == 'http://imbo.local:8000'
 
+    def test_server_urls_as_string(self):
+        client = imbo.Client('imbo.local', 'public', 'private')
+        assert client.server_urls[0] == 'http://imbo.local'
+
     @patch('imboclient.url.status.UrlStatus')
     def test_status_url(self, mocked_url_status):
         status_url = self._client.status_url()

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -55,6 +55,19 @@ class TestClient:
         client = imbo.Client('imbo.local', 'public', 'private')
         assert client.server_urls[0] == 'http://imbo.local'
 
+    def test_server_urls_from_identifiers(self):
+        hosts = ('imbo.local', 'imbo.local2', )
+        client = imbo.Client(hosts, 'public', 'private')
+
+        host1 = str(client.image_url('foo')).split('/')[2]
+
+        # the default method uses the ord() value of the chars, so increase by one to get a different host
+        host2 = str(client.image_url('goo')).split('/')[2]
+
+        assert host1 != host2
+        assert host1 in hosts
+        assert host2 in hosts
+
     @patch('imboclient.url.status.UrlStatus')
     def test_status_url(self, mocked_url_status):
         status_url = self._client.status_url()


### PR DESCRIPTION
Fixes a couple of issues with multiple URLs, avoids always using the first URL sent in, and adds support for supplying a single string as the URL to use instead of requiring a list to be provided (since strings are lists as well, the old code will happily accept the string and then try to use each character as an URL).

