### PR TITLE
Correct image identifier assumptions

### DIFF
--- a/imboclient/test/unit/url/test_image.py
+++ b/imboclient/test/unit/url/test_image.py
@@ -47,7 +47,7 @@ class TestUrlImage:
 
     def test_convert(self):
         result = self._url_image.convert('jpg')
-        assert self._url_image._image_identifier == 'ffffffffffffffffffffffffffffffff.jpg'
+        assert 'ffffffffffffffffffffffffffffffff.jpg' in self._url_image.resource_url()
         assert type(result) is imboclient.url.image.UrlImage
 
     @patch('imboclient.url.image.UrlImage.convert')
@@ -166,8 +166,9 @@ class TestUrlImage:
 
     @patch('imboclient.url.url.Url.reset')
     def test_reset(self, mock_url_reset):
-        self._url_image._image_identifier = 'ffffffffffffffffffffffffffffffffffff'
+        image_identifier = 'ffffffffffffffffffffffffffffffffffff'
+        self._url_image._image_identifier = image_identifier
         result = self._url_image.reset()
         mock_url_reset.assert_called_once_with()
-        assert len(self._url_image._image_identifier) == 32
+        assert len(self._url_image._image_identifier) == len(image_identifier)
         assert type(result) is imboclient.url.image.UrlImage

--- a/imboclient/url/image.py
+++ b/imboclient/url/image.py
@@ -6,9 +6,15 @@ class UrlImage (url.Url):
     def __init__(self, base_url, public_key, private_key, image_identifier, user=None):
         url.Url.__init__(self, base_url, public_key, private_key, user=user)
         self._image_identifier = image_identifier
+        self._type = None
 
     def resource_url(self):
-        return self.user_url('images/' + self._image_identifier)
+        ext = ''
+
+        if self._type:
+            ext = '.' + self._type
+
+        return self.user_url('images/' + self._image_identifier + ext)
 
     def border(self, color='000000', width=1, height=1):
         self.add_query_param('t[]', "border:color={},width={},height={}".format(color, width, height))
@@ -19,7 +25,7 @@ class UrlImage (url.Url):
         return self
 
     def convert(self, ctype):
-        self._image_identifier = self._image_identifier[:32] + '.' + ctype
+        self._type = ctype
         return self
 
     def gif(self):
@@ -106,5 +112,4 @@ class UrlImage (url.Url):
 
     def reset(self):
         url.Url.reset()
-        self._image_identifier = self._image_identifier[:32]
         return self


### PR DESCRIPTION
The previous code assumes that image identifiers are 32 characters, which is an assumption that no longer holds true.

This patch fixes a few issues related to the size of image identifiers and the associated tests.