### PR TITLE
Allow access token generator to specify key name

### DIFF
--- a/imboclient/test/unit/url/test_accesstoken.py
+++ b/imboclient/test/unit/url/test_accesstoken.py
@@ -17,3 +17,9 @@ class TestAccessToken:
         test_result = self._access_token.generate_token(test_url, test_key)
         assert test_result == 'd247e6b332a4bb48fd936e81bc3f9510ac3b23d5ec07880afe3217a9b7d6ff5e'
 
+    def test_token_key_default(self):
+        assert self._access_token.token_key() == 'accessToken'
+
+    def test_token_key_configurable(self):
+        atg = accesstoken.AccessToken(token_key='foo')
+        assert atg.token_key() == 'foo'

--- a/imboclient/url/accesstoken.py
+++ b/imboclient/url/accesstoken.py
@@ -4,9 +4,14 @@ import sys
 
 
 class AccessToken:
+    def __init__(self, token_key='accessToken'):
+        self._token_key = token_key
+
     def generate_token(self, url, key):
         if sys.version_info < (3,):
             return hmac.new(key, url, hashlib.sha256).hexdigest()
         else:
             return hmac.new(bytes(key, 'utf-8'), bytes(url, 'utf-8'), hashlib.sha256).hexdigest()
 
+    def token_key(self):
+        return self._token_key

--- a/imboclient/url/url.py
+++ b/imboclient/url/url.py
@@ -46,7 +46,7 @@ class Url(object):
         generated_token = self.access_token_generator.generate_token(url, self._private_key)
         sep = '?' if not query_string else '&'
 
-        return url + sep + 'accessToken=' + generated_token
+        return url + sep + self.access_token_generator.token_key() + '=' + generated_token
 
     def add_query_param(self, key, value):
         if self._query_params is None:


### PR DESCRIPTION
This patch allows an access token generator implementation specify the token name as well, through the `token_key()` method. 