### PR TITLE
Let add image work with file like objects

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: imboclient
-Version: 0.1.2
+Version: 0.1.3
 Summary: Python client for Imbo
 Home-page: http://www.imbo-project.org
 Author: Andreas Søvik, Mats Lindh

--- a/imboclient/client.py
+++ b/imboclient/client.py
@@ -68,14 +68,25 @@ class Client:
                               user=self._user,
                               access_token_generator=self.access_token_generator)
 
-    def add_image(self, path):
-        image_file_data = self._image_file_data(path)
+    def add_image(self, path_or_filelike_object):
+        data = None
+
+        try:
+            with path_or_filelike_object as f:
+                data = f.read()
+        except AttributeError:
+            with open(path_or_filelike_object, "rb") as f:
+                data = f.read()
+
+        if not data:
+            raise Exception('No valid data read (invalid path / file object did not return any data) when attempting '
+                            'to read image data in add_image')
 
         url = self.images_url().url()
         headers = self._auth_headers('POST', url)
 
         def http_add_image(self):
-            return requests.post(url, data=image_file_data,  headers=headers)
+            return requests.post(url, data=data,  headers=headers)
 
         return self._wrap_result_json(http_add_image, [200, 201], 'Could not add image.')
 

--- a/imboclient/client.py
+++ b/imboclient/client.py
@@ -72,8 +72,12 @@ class Client:
         data = None
 
         try:
-            with path_or_filelike_object as f:
-                data = f.read()
+            # StringIO on Py2 doesn't define __exit__
+            if hasattr(path_or_filelike_object, '__exit__'):
+                with path_or_filelike_object as f:
+                    data = f.read()
+            else:
+                data = path_or_filelike_object.read()
         except AttributeError:
             with open(path_or_filelike_object, "rb") as f:
                 data = f.read()

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -160,6 +160,41 @@ class TestClient:
             result = self._client.add_image('/mocked/image/path.jpg')
             mocked_requests_post.assert_called_once_with('url', data='content', headers={'Accept': 'application/json'})
 
+    @patch('imboclient.header.authenticate.Authenticate.headers')
+    @patch('imboclient.url.images.UrlImages.url')
+    @patch('requests.post')
+    @patch('os.path.isfile')
+    @patch('os.path.getsize')
+    def test_add_image_with_file_object(self, mocked_os_path_getsize, mocked_os_path_isfile, mocked_requests_post, mocked_url, mocked_headers):
+        mocked_os_path_isfile.return_value = True
+        mocked_os_path_getsize.return_value = 7
+
+        response_mock = MagicMock()
+        response_mock.status_code = 201
+
+        mocked_requests_post.return_value = response_mock
+
+        mocked_url.return_value = 'url'
+        mocked_headers.return_value = {'Accept': 'application/json'}
+
+        content = 'content'
+        m = '__builtin__'
+        dummy_data = 'dummy_image_data_to_read'
+
+        if sys.version_info >= (3,):
+            m = 'builtins'
+
+            import io
+            sio = io.StringIO(dummy_data)
+        else:
+            import StringIO
+            sio = StringIO.StringIO(dummy_data)
+
+        mocked_open = mock_open(read_data=content)
+
+        with patch(m + '.open', mocked_open):
+            result = self._client.add_image(sio)
+            mocked_requests_post.assert_called_once_with('url', data=dummy_data, headers={'Accept': 'application/json'})
 
     @patch('imboclient.header.authenticate.Authenticate.headers')
     @patch('requests.post')

--- a/imboclient/test/unit/test_client.py
+++ b/imboclient/test/unit/test_client.py
@@ -190,6 +190,7 @@ class TestClient:
             import StringIO
             sio = StringIO.StringIO(dummy_data)
 
+        # this should not be called
         mocked_open = mock_open(read_data=content)
 
         with patch(m + '.open', mocked_open):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
         name='imboclient',
-        version='0.0.1b',
+        version='0.1.3',
         author='Andreas Søvik',
         author_email='arsovik@gmail.com',
         packages=['imboclient'],


### PR DESCRIPTION
This patch lets `add_image` detect if you've given a file like object instead of a path, allowing a user to directly add images from any store that supports a file like interface for its data.